### PR TITLE
Update python_version for 3.13

### DIFF
--- a/dns.json
+++ b/dns.json
@@ -17,7 +17,7 @@
     "latest_tested_versions": [
         "N/A (Note: tested using Google Public DNS server 8.8.8.8 as of 11/2020)"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "logo": "logo_splunk.svg",
     "logo_dark": "logo_splunk_dark.svg",
     "test_metadata": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)